### PR TITLE
Use project root or fall back to parent folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function activate () {
   }))
   _disposables.add(atom.workspace.observePanes(function (pane) {
     _disposables.add(pane.onDidMoveItem(renameTabs))
+    _disposables.add(pane.onDidActivate(renameTabs))
   }))
   _disposables.add(atom.workspace.onDidOpen(renameTabs))
 
@@ -54,14 +55,23 @@ function renameTabs () {
 
 // todo: allow user to configure this
 function renameTab (tab, tabs) {
-  if (tab.uniqueName) {
-    tab.element.innerText = tab.name
-  } else {
-    var dir = path.dirname(tab.path)
-    var dirs = dir.split(path.sep)
-    var prevDir = dirs[dirs.length - 1]
-    tab.element.innerText = tab.name + ' - ' + prevDir
+  let projectFolder
+
+  // check if tab path in project roots, if so use the project root
+  for (var i = atom.project.rootDirectories.length; i--;) {
+    let rootDir = atom.project.rootDirectories[i]
+    if (tab.path.substr(0, rootDir.path.length) === rootDir.path) {
+      projectFolder = rootDir.path.split(path.sep).pop()
+      break
+    }
   }
+
+  // otherwise, use the file's parent folder
+  if (!projectFolder) {
+    projectFolder = path.dirname(tab.path).split(path.sep).pop()
+  }
+
+  tab.element.innerText = projectFolder + ' — ' + tab.name
 }
 
 module.exports = {


### PR DESCRIPTION
* Instead of always using parent dir, first try using the project root. 
  * Projects structured like `/project/lib/index.js` will be named `project`, not `lib`
* Place project name before file name
  * `/project/lib/index.js` will be named `project - index.js` instead of `index.js - project`
  * This is more helpful as your projects will be named different, but your file names might not. It's quicker to identify between  `project1 - index.js`  and  `project2 - index.js` than between  `index.js - project1`  and `index.js - project2` 
* Changed en-dash (–) to em-dash (—) to align with atom's default format
* Added `pane.onDidActivate` event to hopefully fix cases where the tabs would not be renamed when moving between panes (Possibly fixed #3)